### PR TITLE
Removing MomentJs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 # node modules
 node_modules
+
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Deployed URL -> [https://talent.awsug.in/](https://talent.awsug.in/)
 <br>
 Backend Code -> [https://github.com/CodeOpsTechnologies/Talent-Board-Backend](https://github.com/CodeOpsTechnologies/Talent-Board-Backend)
 <br>
-API Docs -> [http://reskill-documentaion.s3-website-ap-southeast-1.amazonaws.com/#api-AWS_UG_Talent_Board](http://reskill-documentaion.s3-website-ap-southeast-1.amazonaws.com/#api-AWS_UG_Talent_Board)
+API Docs -> [http://talentboard-api-documentation.s3-website-ap-southeast-1.amazonaws.com/](http://talentboard-api-documentation.s3-website-ap-southeast-1.amazonaws.com/)
 
 ## Contributors / Credits 
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@tippyjs/react": "^4.2.5",
     "axios": "^0.21.1",
     "bootstrap": "^5.0.0",
+    "date-fns": "^2.22.1",
     "formik": "^2.2.7",
     "moment": "^2.29.1",
     "react": "^17.0.2",

--- a/src/Pages/SubmissionForm.js
+++ b/src/Pages/SubmissionForm.js
@@ -14,10 +14,10 @@ import {
 } from "../Helpers/constants";
 import _ from "lodash";
 import SuccessModal from "./SuccessModal";
-import moment from "moment";
 import Tippy from "@tippyjs/react";
 import "tippy.js/dist/tippy.css";
 import { toast } from "react-toastify";
+import { add, formatISO } from 'date-fns';
 toast.configure();
 
 const SubmissionForm = () => {
@@ -244,33 +244,29 @@ const SubmissionForm = () => {
     switch (profileExpiresIn) {
       case 1:
         expiresAfter = String(
-          moment(new Date()).add("15", "days")._d.toISOString()
-        ).slice(0, 10);
-        break;
+          formatISO(add(new Date(), { days: 15 }), { representation: "date" })
+          )
+          break;
       case 2:
         expiresAfter = String(
-          moment(new Date()).add("30", "days")._d.toISOString()
-        ).slice(0, 10);
+           formatISO(add(new Date(), { days: 30 }), { representation: "date" }))
         break;
       case 3:
         expiresAfter = String(
-          moment(new Date()).add("45", "days")._d.toISOString()
-        ).slice(0, 10);
+           formatISO(add(new Date(), { days: 45 }), { representation: "date" })
+        )
         break;
       case 4:
         expiresAfter = String(
-          moment(new Date()).add("60", "days")._d.toISOString()
-        ).slice(0, 10);
+           formatISO(add(new Date(), { days: 60 }), { representation: "date" }))
         break;
       case 5:
         expiresAfter = String(
-          moment(new Date()).add("90", "days")._d.toISOString()
-        ).slice(0, 10);
+           formatISO(add(new Date(), { days: 90 }), { representation: "date" }))
         break;
       default:
         expiresAfter = String(
-          moment(new Date()).add("30", "days")._d.toISOString()
-        ).slice(0, 10);
+           formatISO(add(new Date(), { days: 30 }), { representation: "date" }))
     }
 
     if (!finalValidate()) return;


### PR DESCRIPTION
The size of Moment.js is around 500kb and the size of date-fns as it is modular we reduce the size to bytes while achieving the same results.
⚠ [Read this](https://momentjs.com/docs/#:~:text=we%20now%20generally%20consider%20moment%20to%20be%20a%20legacy%20project%20in%20maintenance%20mode.%20it%20is%20not%20dead%2C%20but%20it%20is%20indeed%20done.) 

Related Articles Supporting why using moment Js is a bad idea ->[Article 1](https://raygun.com/blog/moment-js-vs-date-fns/) , [Article 2](https://javascript-conference.com/blog/why-you-should-use-date-fns-for-manipulating-dates-with-javascript/)